### PR TITLE
Fix crash when notification button tapped after service restart

### DIFF
--- a/app/src/main/java/org/staacks/alpharemote/service/AlphaRemoteService.kt
+++ b/app/src/main/java/org/staacks/alpharemote/service/AlphaRemoteService.kt
@@ -84,6 +84,13 @@ class AlphaRemoteService : CompanionDeviceService() {
         var broadcastControl = false
     }
 
+    override fun onCreate() {
+        super.onCreate()
+        pendingActionsWakeLock = (getSystemService(POWER_SERVICE) as PowerManager).run {
+            newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "AlphaRemoteService::PendingActionsWakeLock")
+        }
+    }
+
     override fun onDeviceAppeared(address: String) {
         Log.d(MainActivity.TAG, "Device appeared: $address")
         try {
@@ -120,10 +127,6 @@ class AlphaRemoteService : CompanionDeviceService() {
                 }
             }
         })
-
-        pendingActionsWakeLock = (getSystemService(POWER_SERVICE) as PowerManager).run {
-            newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "AlphaRemoteService::PendingActionsWakeLock")
-        }
 
         if (cameraBLE == null) {
             cancelPendingActionSteps()


### PR DESCRIPTION
## Summary

- `pendingActionsWakeLock` was initialized in `onDeviceAppeared()`, but Android can call `onStartCommand()` before `onDeviceAppeared()` when the service is killed and restarted
- Tapping a notification button in this state triggered `cancelPendingActionSteps()` → `UninitializedPropertyAccessException` → crash
- Fixed by moving the wake lock initialization to `onCreate()`, which is always called before `onStartCommand()`

## Root cause

```
kotlin.UninitializedPropertyAccessException: lateinit property pendingActionsWakeLock has not been initialized
    at AlphaRemoteService.cancelPendingActionSteps(AlphaRemoteService.kt:300)
    at AlphaRemoteService.startCameraAction(AlphaRemoteService.kt:320)
    at AlphaRemoteService.onStartCommand(AlphaRemoteService.kt:236)
```

Verified on my phone, Oppo A53, Android 12, I think this will also solve #25 

🤖 Generated with [Claude Code](https://claude.com/claude-code)